### PR TITLE
Added support for constant attribute expressions

### DIFF
--- a/RoslynDomCSharpFactories/BuildSyntaxHelpers.cs
+++ b/RoslynDomCSharpFactories/BuildSyntaxHelpers.cs
@@ -158,6 +158,7 @@ namespace RoslynDom.CSharp
         {
             switch (kind)
             {
+                case LiteralKind.Constant:
                 case LiteralKind.String:
                 case LiteralKind.Unknown:
                 return SyntaxFactory.Literal(value.ToString());

--- a/RoslynDomCSharpFactories/CreateFromWorker.cs
+++ b/RoslynDomCSharpFactories/CreateFromWorker.cs
@@ -294,6 +294,16 @@ namespace RoslynDom.CSharp
                          .FirstOrDefault()
                          as IReferencedType;
                 }
+                else
+                {
+                    // If all else fails, try to get constant value
+                    var constant = model.GetConstantValue(expr);
+                    if (constant.HasValue)
+                    {
+                        literalKind = LiteralKind.Constant;
+                        value = constant.Value;
+                    }
+                }
             }
             return Tuple.Create(value, literalKind);
         }

--- a/RoslynDomCSharpFactories/Mappings.cs
+++ b/RoslynDomCSharpFactories/Mappings.cs
@@ -14,6 +14,7 @@ namespace RoslynDom.CSharp
         private static List<Tuple<SyntaxKind, SyntaxKind, LiteralKind>> LiteralKindMap = new List<Tuple<SyntaxKind, SyntaxKind, LiteralKind>>()
         {
             Tuple.Create(SyntaxKind.StringLiteralToken,    SyntaxKind.StringLiteralExpression,     LiteralKind.String),
+            Tuple.Create(SyntaxKind.StringLiteralToken,    SyntaxKind.StringLiteralExpression,     LiteralKind.Constant),
             Tuple.Create( SyntaxKind.NumericLiteralToken,   SyntaxKind.NumericLiteralExpression,   LiteralKind.Numeric),
             Tuple.Create( SyntaxKind.TrueKeyword,           SyntaxKind.TrueKeyword,                LiteralKind.Boolean),
             Tuple.Create( SyntaxKind.FalseKeyword,          SyntaxKind.FalseKeyword,               LiteralKind.Boolean),

--- a/RoslynDomCommon/Enums/LiteralKind.cs
+++ b/RoslynDomCommon/Enums/LiteralKind.cs
@@ -6,6 +6,7 @@
         Numeric,
         Boolean,
         String,
-        Type
+        Type,
+        Constant
     }
 }

--- a/RoslynDomTests/AttributeTests.cs
+++ b/RoslynDomTests/AttributeTests.cs
@@ -659,6 +659,38 @@ namespace RoslynDomTests
 
         }
 
+        [TestMethod, TestCategory(AttributeValuesCategory)]
+        public void Can_get_exression_attribute_value()
+        {
+            var source = @"
+using System;
+
+namespace Test
+{
+    public class ContractNamespaceAttribute : Attribute
+    {
+        public ContractNamespaceAttribute(string text)
+        {
+        }
+
+        public Type MyType {get; set;}
+    }
+
+    public class Const
+    {
+        public const string Test = ""TestContract"";
+    }
+
+    [ContractNamespace(Const.Test)]
+    class TestClass
+    {
+    }
+}";
+            var attributes = VerifyAttributes(source, root => root.RootClasses.First(x => x.Name == "TestClass").Attributes, 1, true, "ContractNamespace").ToArray();
+            var attributeValues = VerifyAttributeValues(attributes[0], count: 1).ToArray();
+            VerifyAttributeValue(attributeValues[0], name: "", value: "TestContract", kind: LiteralKind.Constant);
+        }
+
         #endregion
 
         #region get root class attributes

--- a/RoslynDomTests/PlaySpace.cs
+++ b/RoslynDomTests/PlaySpace.cs
@@ -49,10 +49,16 @@ namespace RoslynDom
                     var y = 42;
                     z = x + y;
                 }
-                catch (InvalidOperationException ex) if (z == 45)
-                { Console.WriteLine(ex + " " + z); }
+                catch (InvalidOperationException ex)
+                {
+                    if (z == 45)
+                    {
+                        Console.WriteLine(ex + " " + z);
+                    }
+                }
                 catch
-                { }
+                {
+                }
                 var length = 10;
                 for (int i = 0, j = 3; i < length && j < length; i++, j++)
                 {


### PR DESCRIPTION
Hello!

First of all, thank you for a great library! I'm trying to incorporate it into our company's internal tool and I really need suport for constant expressions in attributes, like this one:

[ContractNamespace(Const.Test)]

I've made some changes to resolve constant values upon DOM construction, but it's not scalable and syntax builder doesn't work correctly. Since I only need to parse .cs sources, this patch will work for me for the time being. But it would be really great if you were to add this feature in one of the next versions.

Of course, I don't expect this pull request to be accepted since it breaks syntax builder, it's just an easy way to explain what I mean.
