### PR TITLE
Fixed two paths where invalid code was throwing an exception.

### DIFF
--- a/RoslynDomCSharpFactories/CreateFromWorker.cs
+++ b/RoslynDomCSharpFactories/CreateFromWorker.cs
@@ -258,8 +258,8 @@ namespace RoslynDom.CSharp
                  IEnumerable<UsingDirectiveSyntax> usingSyntaxes,
                  SemanticModel model)
       {
-         newItem.StemMembersAll.CreateAndAdd(usingSyntaxes, x => Corporation.Create(x, newItem, model).Cast<IStemMemberAndDetail>());
-         newItem.StemMembersAll.CreateAndAdd(memberSyntaxes, x => Corporation.Create(x, newItem, model).Cast<IStemMemberAndDetail>());
+         newItem.StemMembersAll.CreateAndAdd(usingSyntaxes, x => Corporation.Create(x, newItem, model).OfType<IStemMemberAndDetail>());
+         newItem.StemMembersAll.CreateAndAdd(memberSyntaxes, x => Corporation.Create(x, newItem, model).OfType<IStemMemberAndDetail>());
       }
 
       public IEnumerable<IDetail> GetDetail<T, TSyntax>(

--- a/RoslynDomCSharpFactories/Factories/RDomStructuredDocumentationFactory.cs
+++ b/RoslynDomCSharpFactories/Factories/RDomStructuredDocumentationFactory.cs
@@ -41,40 +41,42 @@ namespace RoslynDom.CSharp
          if (parentAsHasSymbol != null)
          {
             var symbol = parentAsHasSymbol.Symbol;
-            var docString = symbol.GetDocumentationCommentXml();
-            if (!string.IsNullOrEmpty(docString))
-            {
-               IEnumerable<SyntaxTrivia> leadingTrivia = syntaxNode.GetLeadingTrivia();
-               if (leadingTrivia
-                               .Any(x => x.Kind() == SyntaxKind.MultiLineDocumentationCommentTrivia))
-               { throw new NotImplementedException(); }
+            if (symbol != null) {
+               var docString = symbol.GetDocumentationCommentXml();
+               if (!string.IsNullOrEmpty(docString))
+               {
+                  IEnumerable<SyntaxTrivia> leadingTrivia = syntaxNode.GetLeadingTrivia();
+                  if (leadingTrivia
+                                  .Any(x => x.Kind() == SyntaxKind.MultiLineDocumentationCommentTrivia))
+                  { throw new NotImplementedException(); }
 
-               var trivia = leadingTrivia
-                               .Where(x => x.Kind() == SyntaxKind.SingleLineDocumentationCommentTrivia)
-                               .First();
-               var precedingTrivia = leadingTrivia.PreviousSiblings<SyntaxTrivia>(trivia)
-                               .LastOrDefault();
-               var leadingWs = "";
-               if (precedingTrivia.Kind() == SyntaxKind.WhitespaceTrivia)
-               { leadingWs = precedingTrivia.ToFullString(); }
-               var xDocument = XDocument.Parse(docString);
-               var summaryNode = xDocument.DescendantNodes()
-                                   .OfType<XElement>()
-                                   .Where(x => x.Name == "summary")
-                                   .Select(x => x.Value);
-               var newWs = new Whitespace2(LanguagePart.Current, LanguageElement.DocumentationComment);
-               newWs.LeadingWhitespace = leadingWs;
-               newItem.Whitespace2Set.Add(newWs);
+                  var trivia = leadingTrivia
+                                  .Where(x => x.Kind() == SyntaxKind.SingleLineDocumentationCommentTrivia)
+                                  .First();
+                  var precedingTrivia = leadingTrivia.PreviousSiblings<SyntaxTrivia>(trivia)
+                                  .LastOrDefault();
+                  var leadingWs = "";
+                  if (precedingTrivia.Kind() == SyntaxKind.WhitespaceTrivia)
+                  { leadingWs = precedingTrivia.ToFullString(); }
+                  var xDocument = XDocument.Parse(docString);
+                  var summaryNode = xDocument.DescendantNodes()
+                                      .OfType<XElement>()
+                                      .Where(x => x.Name == "summary")
+                                      .Select(x => x.Value);
+                  var newWs = new Whitespace2(LanguagePart.Current, LanguageElement.DocumentationComment);
+                  newWs.LeadingWhitespace = leadingWs;
+                  newItem.Whitespace2Set.Add(newWs);
 
-               //var description = summaryNode.FirstOrDefault().Replace("\r", "").Replace("\n", "");
-               var description = summaryNode.FirstOrDefault();
-               leadingWs = description.SubstringBefore(description.Trim());
-               newWs = new Whitespace2(LanguagePart.Inner, LanguageElement.DocumentationComment);
-               newWs.LeadingWhitespace = leadingWs;
-               newItem.Whitespace2Set.Add(newWs);
+                  //var description = summaryNode.FirstOrDefault().Replace("\r", "").Replace("\n", "");
+                  var description = summaryNode.FirstOrDefault();
+                  leadingWs = description.SubstringBefore(description.Trim());
+                  newWs = new Whitespace2(LanguagePart.Inner, LanguageElement.DocumentationComment);
+                  newWs.LeadingWhitespace = leadingWs;
+                  newItem.Whitespace2Set.Add(newWs);
 
-               newItem.Description = description.Trim();
-               newItem.Document = docString;
+                  newItem.Description = description.Trim();
+                  newItem.Document = docString;
+               }
             }
          }
 

--- a/RoslynDomCSharpFactories/Factories/RDomStructuredDocumentationFactory.cs
+++ b/RoslynDomCSharpFactories/Factories/RDomStructuredDocumentationFactory.cs
@@ -41,7 +41,8 @@ namespace RoslynDom.CSharp
          if (parentAsHasSymbol != null)
          {
             var symbol = parentAsHasSymbol.Symbol;
-            if (symbol != null) {
+            if (symbol != null)
+            {
                var docString = symbol.GetDocumentationCommentXml();
                if (!string.IsNullOrEmpty(docString))
                {

--- a/RoslynDomTests/FactoryTests.cs
+++ b/RoslynDomTests/FactoryTests.cs
@@ -101,7 +101,6 @@ namespace RoslynDomTests
       [TestMethod, TestCategory(GeneralFactoryCategory)]
       public void Can_get_root_from_string_with_invalid_code()
       {
-         Assert.Inconclusive(); // This code can't build a valid IDom structure, not sure how to report
          var csharpCode = @"
                         using System.Diagnostics.Tracing;
                         namespace testing.Namespace1
@@ -112,6 +111,15 @@ namespace RoslynDomTests
          var root = RDom.CSharp.Load(csharpCode);
          Assert.IsNotNull(root);
          Assert.AreEqual(1, root.ChildNamespaces.Count());
+      }
+
+      [TestMethod, TestCategory(GeneralFactoryCategory)]
+      public void Can_get_root_from_string_with_invalid_code2()
+      {
+         var csharpCode = @"foo";
+         var root = RDom.CSharp.Load(csharpCode);
+         Assert.IsNotNull(root);
+         Assert.AreEqual(0, root.Descendants.Count());
       }
 
       [TestMethod, TestCategory(GeneralFactoryCategory)]


### PR DESCRIPTION
Fixes #101
- `RDomStructuredDocumentationFactory.CreateItem`: ignore the symbol if it's null (fixes NullReferenceException).
- `CreateFromWorker.LoadStemMembers`: ignore non stem members (fixes InvalidOperationException).

Added a test that fails prior to the changes, and passes after (`Can_get_root_from_string_with_invalid_code2`).
Also removed `Assert.Inconclusive` from `Can_get_root_from_string_with_invalid_code` since it now passes.
